### PR TITLE
feat: Scaffold Nyota Studio monorepo structure

### DIFF
--- a/nyota/apps/desktop/README.md
+++ b/nyota/apps/desktop/README.md
@@ -1,0 +1,3 @@
+# Nyota Studio - Desktop
+
+This directory contains the source code for the Nyota Studio desktop application, built with Tauri and React.

--- a/nyota/apps/mobile/README.md
+++ b/nyota/apps/mobile/README.md
@@ -1,0 +1,3 @@
+# Nyota Studio - Mobile App
+
+This directory contains the source code for the Nyota Studio mobile application, built with React Native.

--- a/nyota/apps/web/README.md
+++ b/nyota/apps/web/README.md
@@ -1,0 +1,3 @@
+# Nyota Studio - Web App
+
+This directory contains the source code for the Nyota Studio web application, built with Next.js.

--- a/nyota/apps/web/app/(auth)/sign-in/README.md
+++ b/nyota/apps/web/app/(auth)/sign-in/README.md
@@ -1,0 +1,2 @@
+# Sign-In Page
+This directory contains the sign-in page for the web application, featuring the Thirdweb SIWE ConnectButton.

--- a/nyota/apps/web/app/(auth)/sign-in/page.tsx
+++ b/nyota/apps/web/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,17 @@
+// app/(auth)/sign-in/page.tsx
+"use client";
+import { ConnectButton } from "thirdweb/react";
+import { client } from "@/app/providers";
+export default function SignIn() {
+  return (
+    <ConnectButton
+      client={client}
+      auth={{
+        getLoginPayload: async (p) => (await fetch("/api/auth/payload",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(p),credentials:"include"})).json(),
+        doLogin: async (params) => fetch("/api/auth/login",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(params),credentials:"include"}),
+        isLoggedIn: async () => (await (await fetch("/api/auth/is-logged-in",{credentials:"include"})).json()).loggedIn,
+        doLogout: async () => fetch("/api/auth/logout",{method:"POST",credentials:"include"}),
+      }}
+    />
+  );
+}

--- a/nyota/apps/web/app/README.md
+++ b/nyota/apps/web/app/README.md
@@ -1,0 +1,3 @@
+# Next.js App Directory
+
+This directory contains the pages and components for the Next.js application, following the App Router convention.

--- a/nyota/apps/web/app/checkout/README.md
+++ b/nyota/apps/web/app/checkout/README.md
@@ -1,0 +1,2 @@
+# Checkout Page
+This directory contains the checkout page for the web application, featuring the Thirdweb CheckoutWidget.

--- a/nyota/apps/web/app/checkout/page.tsx
+++ b/nyota/apps/web/app/checkout/page.tsx
@@ -1,0 +1,19 @@
+// app/checkout/page.tsx
+"use client";
+import { CheckoutWidget } from "thirdweb/react";
+import { client } from "@/app/providers";
+import { base } from "thirdweb/chains";
+export default function Checkout() {
+  return (
+    <CheckoutWidget
+      client={client}
+      chain={base}
+      amount="9.99"
+      currency="USD"
+      seller={process.env.NEXT_PUBLIC_SELLER_ADDRESS!}
+      paymentMethods={["card","crypto"]}
+      metadata={{ name: "AI Pro Credits", description: "10,000 credits" }}
+      onPurchaseSuccess={(evt) => fetch("/api/payments/fulfill",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(evt),credentials:"include"})}
+    />
+  );
+}

--- a/nyota/apps/web/app/providers.tsx
+++ b/nyota/apps/web/app/providers.tsx
@@ -1,0 +1,8 @@
+// app/providers.tsx
+"use client";
+import { ThirdwebProvider } from "thirdweb/react";
+import { createThirdwebClient } from "thirdweb";
+import { base } from "thirdweb/chains";
+export const client = createThirdwebClient({ clientId: process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID! });
+export default ({ children }: { children: React.ReactNode }) =>
+  <ThirdwebProvider client={client} activeChain={base}>{children}</ThirdwebProvider>;

--- a/nyota/crates/core/README.md
+++ b/nyota/crates/core/README.md
@@ -1,0 +1,3 @@
+# Nyota Core
+
+This crate contains the core Rust SDK for Nyota Studio, providing services for policy routing, storage, cryptography, and job graph management.

--- a/nyota/packages/sdk-ts/README.md
+++ b/nyota/packages/sdk-ts/README.md
@@ -1,0 +1,3 @@
+# Nyota TypeScript SDK
+
+This package provides the TypeScript SDK for interacting with Nyota services, including providers and presets.

--- a/nyota/packages/ui/README.md
+++ b/nyota/packages/ui/README.md
@@ -1,0 +1,3 @@
+# Nyota UI
+
+This package contains the design system and shared UI components for Nyota Studio applications.

--- a/nyota/services/ai-gateway/README.md
+++ b/nyota/services/ai-gateway/README.md
@@ -1,0 +1,3 @@
+# Nyota AI Gateway
+
+This service, built with FastAPI, manages Hugging Face pipelines, model operations, and media processing jobs.

--- a/nyota/services/gpu-worker/README.md
+++ b/nyota/services/gpu-worker/README.md
@@ -1,0 +1,3 @@
+# Nyota GPU Worker
+
+This service contains the GPU worker pipelines, using Torch, ONNX, and TensorRT for accelerated AI tasks.


### PR DESCRIPTION
This commit introduces the initial directory structure and scaffolding for the Nyota Studio project, based on the Product Development Requirements (PDR).

It creates the full monorepo skeleton, including directories for:
- `apps/`: desktop, web, and mobile applications
- `crates/`: core Rust SDK
- `services/`: AI gateway and GPU worker
- `packages/`: TypeScript SDK and UI components

Additionally, it populates the web app (`apps/web`) with the minimal scaffolds for Thirdweb integration, as specified in the PDR:
- `providers.tsx`: ThirdwebProvider setup
- `(auth)/sign-in/page.tsx`: SIWE ConnectButton
- `checkout/page.tsx`: CheckoutWidget

Placeholder README.md files have been added to each directory to document its purpose.